### PR TITLE
TSK-ID-12 Fix Player Rotation

### DIFF
--- a/app/src/androidTest/java/com/appelier/bluetubecompose/ui/screens/video_list/VideoListScreenKtTest.kt
+++ b/app/src/androidTest/java/com/appelier/bluetubecompose/ui/screens/video_list/VideoListScreenKtTest.kt
@@ -25,6 +25,7 @@ import com.appelier.bluetubecompose.MainActivity
 import com.appelier.bluetubecompose.R
 import com.appelier.bluetubecompose.core.core_database.CustomNavTypeSerializer
 import com.appelier.bluetubecompose.navigation.ScreenType
+import com.appelier.bluetubecompose.screen_player.OrientationState
 import com.appelier.bluetubecompose.screen_player.PlayerScreen
 import com.appelier.bluetubecompose.screen_video_list.model.videos.YoutubeVideo
 import com.appelier.bluetubecompose.screen_video_list.model.videos.YoutubeVideo.Companion.DEFAULT_VIDEO_LIST
@@ -95,11 +96,16 @@ class VideoListScreenKtTest {
                     PlayerScreen(
                         video = video,
                         relatedVideos = { mutableStateOf(MutableStateFlow(PagingData.from(DEFAULT_VIDEO_LIST))) },
-                        MutableStateFlow(true),
+                        isVideoPlaysFlow = MutableStateFlow(true),
+                        {},
                         navigateToPlayerScreen = {},
                         popBackStack = {},
                         updatePlaybackPosition = {},
-                        getPlaybackPosition = { initialPlaybackPosition }
+                        getPlaybackPosition = { initialPlaybackPosition },
+                        MutableStateFlow(OrientationState.PORTRAIT),
+                        {},
+                        MutableStateFlow(false),
+                        {}
                     )
                 }
             }

--- a/app/src/androidTest/java/com/appelier/bluetubecompose/ui/screens/video_player/PlayerScreenKtTest.kt
+++ b/app/src/androidTest/java/com/appelier/bluetubecompose/ui/screens/video_player/PlayerScreenKtTest.kt
@@ -30,18 +30,22 @@ import com.appelier.bluetubecompose.R
 import com.appelier.bluetubecompose.core.core_database.CustomNavTypeSerializer
 import com.appelier.bluetubecompose.navigation.ScreenType
 import com.appelier.bluetubecompose.screen_player.PlayerScreen
+import com.appelier.bluetubecompose.screen_player.VideoPlayerViewModel
 import com.appelier.bluetubecompose.screen_video_list.model.videos.YoutubeVideo
 import com.appelier.bluetubecompose.screen_video_list.model.videos.YoutubeVideoResponse.Companion.DEFAULT_VIDEO_RESPONSE_WITH_CHANNEL_IMG
+import com.appelier.bluetubecompose.screen_video_list.repository.VideoListRepository
 import com.appelier.bluetubecompose.utils.VideoListScreenTags
 import com.appelier.bluetubecompose.utils.VideoPlayerScreenTags
 import dagger.hilt.android.testing.HiltAndroidRule
 import dagger.hilt.android.testing.HiltAndroidTest
 import kotlinx.coroutines.flow.MutableStateFlow
-import org.junit.Assert.*
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertNotEquals
 import org.junit.Before
 import org.junit.Rule
 import org.junit.Test
 import org.junit.runner.RunWith
+import org.mockito.kotlin.mock
 import kotlin.reflect.typeOf
 
 @RunWith(AndroidJUnit4::class)
@@ -60,6 +64,8 @@ class PlayerScreenKtTest {
     private val firstVideo = DEFAULT_VIDEO_RESPONSE_WITH_CHANNEL_IMG.items.first()
     private val secondVideo = DEFAULT_VIDEO_RESPONSE_WITH_CHANNEL_IMG.items[1]
     private var videoId: String = ""
+    private val repository: VideoListRepository = mock()
+    private val viewModel = VideoPlayerViewModel(repository)
 
     @Before
     fun init_player_screen() {
@@ -87,7 +93,8 @@ class PlayerScreenKtTest {
                     PlayerScreen(
                         video = video,
                         relatedVideos = { videoPage },
-                        MutableStateFlow(true),
+                        isVideoPlaysFlow = MutableStateFlow(true),
+                        {},
                         navigateToPlayerScreen = {
                             navController.navigate(ScreenType.PlayerScreen(secondVideo)) {
                                 launchSingleTop = true
@@ -95,7 +102,15 @@ class PlayerScreenKtTest {
                         },
                         popBackStack = {},
                         updatePlaybackPosition = {},
-                        getPlaybackPosition = { 0F }
+                        getPlaybackPosition = { 0F },
+                        playerOrientationState = viewModel.playerOrientationState,
+                        updatePlayerOrientationState = { newPlayerOrientationState ->
+                            viewModel.updatePlayerOrientationState(
+                                newPlayerOrientationState
+                            )
+                        },
+                        viewModel.fullscreenWidgetIsClicked,
+                        { isClicked -> viewModel.setFullscreenWidgetIsClicked(isClicked) }
                     )
                 }
             }

--- a/app/src/main/java/com/appelier/bluetubecompose/navigation/Navigation.kt
+++ b/app/src/main/java/com/appelier/bluetubecompose/navigation/Navigation.kt
@@ -77,6 +77,11 @@ fun Navigation(
                     video = arg,
                     relatedVideos = { playerScreenViewModel.getRelatedVideosState() },
                     isVideoPlaysFlow = playerScreenViewModel.isVideoPlaysFlow,
+                    updateVideoIsPlayState = { isPlaying ->
+                        playerScreenViewModel.updateVideoIsPlayState(
+                            isPlaying
+                        )
+                    },
                     navigateToPlayerScreen = { video: YoutubeVideo ->
                         navController.navigate(ScreenType.PlayerScreen(video)) {
                             launchSingleTop = true
@@ -88,14 +93,26 @@ fun Navigation(
                             playbackPosition
                         )
                     },
-                    getPlaybackPosition = { playerScreenViewModel.getCurrentPlaybackPosition() }
+                    getPlaybackPosition = { playerScreenViewModel.getCurrentPlaybackPosition() },
+                    playerOrientationState = playerScreenViewModel.playerOrientationState,
+                    updatePlayerOrientationState = { newPlayerOrientationState ->
+                        playerScreenViewModel.updatePlayerOrientationState(
+                            newPlayerOrientationState
+                        )
+                    },
+                    fullscreenWidgetIsClicked = playerScreenViewModel.fullscreenWidgetIsClicked,
+                    setFullscreenWidgetIsClicked = { isClicked ->
+                        playerScreenViewModel.setFullscreenWidgetIsClicked(
+                            isClicked
+                        )
+                    }
                 )
             }
             composable<ScreenType.ShortsScreen> {
                 val shortsViewModel: ShortsViewModel = hiltViewModel()
                 shortsViewModel.getShorts()
                 ShortsScreen(
-                    { shortsViewModel.getShortsVideo() } ,
+                    { shortsViewModel.getShortsVideo() },
                     shortsViewModel.videoQueue
                 ) { shortsViewModel.listenToVideoQueue() }
             }

--- a/app/src/main/java/com/appelier/bluetubecompose/screen_player/PlayerScreen.kt
+++ b/app/src/main/java/com/appelier/bluetubecompose/screen_player/PlayerScreen.kt
@@ -14,18 +14,22 @@ import com.appelier.bluetubecompose.core.core_ui.views.video_list_screen.VideoDe
 import com.appelier.bluetubecompose.core.core_ui.views.video_list_screen.YouTubeVideoList
 import com.appelier.bluetubecompose.core.core_ui.views.YoutubeVideoPlayer
 import com.appelier.bluetubecompose.screen_video_list.model.videos.YoutubeVideo
-import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
 
 @Composable
 fun PlayerScreen(
     video: YoutubeVideo,
     relatedVideos: () -> State<StateFlow<PagingData<YoutubeVideo>>>,
-    isVideoPlaysFlow: MutableStateFlow<Boolean>,
+    isVideoPlaysFlow: StateFlow<Boolean>,
+    updateVideoIsPlayState: (Boolean) -> Unit,
     navigateToPlayerScreen: (YoutubeVideo) -> Unit,
     popBackStack: () -> Unit,
     updatePlaybackPosition: (Float) -> Unit,
     getPlaybackPosition: () -> Float,
+    playerOrientationState: StateFlow<OrientationState>,
+    updatePlayerOrientationState: (OrientationState) -> Unit,
+    fullscreenWidgetIsClicked: StateFlow<Boolean>,
+    setFullscreenWidgetIsClicked: (Boolean) -> Unit
 ) {
     Scaffold(
         content = { paddingValue ->
@@ -37,9 +41,14 @@ fun PlayerScreen(
                     videoId = video.id,
                     Modifier,
                     isVideoPlaysFlow,
+                    updateVideoIsPlayState,
                     popBackStack,
                     updatePlaybackPosition,
                     getPlaybackPosition,
+                    playerOrientationState,
+                    updatePlayerOrientationState,
+                    fullscreenWidgetIsClicked,
+                    setFullscreenWidgetIsClicked
                 )
 
                 if (LocalConfiguration.current.orientation != ActivityInfo.SCREEN_ORIENTATION_SENSOR_LANDSCAPE) {

--- a/app/src/main/java/com/appelier/bluetubecompose/screen_player/VideoPlayerViewModel.kt
+++ b/app/src/main/java/com/appelier/bluetubecompose/screen_player/VideoPlayerViewModel.kt
@@ -29,8 +29,17 @@ class VideoPlayerViewModel @Inject constructor(
         MutableStateFlow(emptyPagingData)
     )
     private val relatedVideoStateFlow: State<StateFlow<PagingData<YoutubeVideo>>> get() = _relatedVideoStateFlow
+
     private var videoPlaybackPosition: Float = INITIAL_VIDEO_PLAYBACK_POSITION
-    var isVideoPlaysFlow = MutableStateFlow(true)
+
+    private val _isVideoPlaysFlow = MutableStateFlow(true)
+    val isVideoPlaysFlow: StateFlow<Boolean> = _isVideoPlaysFlow
+
+    private var _playerOrientationState = MutableStateFlow(OrientationState.PORTRAIT)
+    val playerOrientationState: StateFlow<OrientationState> = _playerOrientationState
+
+    private var _fullscreenWidgetIsClicked = MutableStateFlow(false)
+    val fullscreenWidgetIsClicked:StateFlow<Boolean> = _fullscreenWidgetIsClicked
 
     fun getRelatedVideosState() = relatedVideoStateFlow
 
@@ -52,5 +61,17 @@ class VideoPlayerViewModel @Inject constructor(
 
             _relatedVideoStateFlow = mutableStateOf(relatedVideosFlow)
         }
+    }
+
+    fun updateVideoIsPlayState(isPlaying: Boolean) {
+        _isVideoPlaysFlow.value = isPlaying
+    }
+
+    fun updatePlayerOrientationState(newPlayerOrientationState: OrientationState) {
+        _playerOrientationState.value = newPlayerOrientationState
+    }
+
+    fun setFullscreenWidgetIsClicked(isClicked: Boolean) {
+        _fullscreenWidgetIsClicked.value = isClicked
     }
 }

--- a/app/src/main/java/com/appelier/bluetubecompose/screen_player/YouTubePlayerHandler.kt
+++ b/app/src/main/java/com/appelier/bluetubecompose/screen_player/YouTubePlayerHandler.kt
@@ -1,7 +1,5 @@
 package com.appelier.bluetubecompose.screen_player
 
-import android.app.Activity
-import androidx.compose.runtime.MutableState
 import androidx.lifecycle.Lifecycle
 import com.appelier.bluetubecompose.databinding.FragmentPlayVideoBinding
 import com.pierfrancescosoffritti.androidyoutubeplayer.core.player.PlayerConstants
@@ -11,17 +9,16 @@ import com.pierfrancescosoffritti.androidyoutubeplayer.core.player.options.IFram
 
 class YouTubePlayerHandler(
     private val binding: FragmentPlayVideoBinding,
-    playerOrientationState: MutableState<OrientationState>,
-    activity: Activity,
     private val currentComposeLifecycle: Lifecycle,
     private val videoId: String,
-    private var isVideoPlays: MutableState<Boolean>,
-    private val updatePlaybackPosition:(Float) -> Unit,
-    private val getCurrentPlaybackPosition: () -> Float
+    private val isVideoPlays: Boolean,
+    private val updateVideoIsPlayState: (Boolean) -> Unit,
+    private val updatePlaybackPosition: (Float) -> Unit,
+    private val getCurrentPlaybackPosition: () -> Float,
+    private val orientationHandler: OrientationHandler,
 ) {
 
     var player: YouTubePlayer? = null
-    private val orientationHandler = OrientationHandler(binding, activity, playerOrientationState)
 
     init {
         setupPlayerWidgets()
@@ -44,8 +41,9 @@ class YouTubePlayerHandler(
                 player = youTubePlayer
 
                 orientationHandler.initFullScreenWidgetState(player)
+                orientationHandler.setOnFullscreenClickListener(player)
 
-                when(isVideoPlays.value) {
+                when (isVideoPlays) {
                     true -> youTubePlayer.loadVideo(videoId, getCurrentPlaybackPosition.invoke())
                     false -> youTubePlayer.cueVideo(videoId, getCurrentPlaybackPosition.invoke())
                 }
@@ -56,13 +54,15 @@ class YouTubePlayerHandler(
                 state: PlayerConstants.PlayerState
             ) {
                 super.onStateChange(youTubePlayer, state)
-                when(state) {
+                when (state) {
                     PlayerConstants.PlayerState.PAUSED -> {
-                        isVideoPlays.value = false
+                        updateVideoIsPlayState(false)
                     }
+
                     PlayerConstants.PlayerState.PLAYING -> {
-                        isVideoPlays.value = true
+                        updateVideoIsPlayState(true)
                     }
+
                     else -> {}
                 }
             }
@@ -72,13 +72,5 @@ class YouTubePlayerHandler(
                 updatePlaybackPosition.invoke(second)
             }
         }
-    }
-
-    fun changeToPortraitOrientation() {
-        orientationHandler.changeToPortraitOrientation()
-    }
-
-    fun setScreenAppearanceOrientationFlag(orientation: Int) {
-        orientationHandler.setScreenAppearanceOrientationFlag(orientation)
     }
 }

--- a/app/src/main/res/layout-land/fragment_play_video.xml
+++ b/app/src/main/res/layout-land/fragment_play_video.xml
@@ -15,4 +15,12 @@
         app:layout_constraintStart_toStartOf="parent"
         app:layout_constraintTop_toTopOf="parent" />
 
+    <View
+        android:id="@+id/full_screen_button"
+        android:layout_width="44dp"
+        android:layout_height="44dp"
+        android:layout_margin="8dp"
+        app:layout_constraintEnd_toEndOf="@id/yt_player"
+        app:layout_constraintBottom_toBottomOf="@id/yt_player"/>
+
 </androidx.constraintlayout.widget.ConstraintLayout>

--- a/app/src/main/res/layout/fragment_play_video.xml
+++ b/app/src/main/res/layout/fragment_play_video.xml
@@ -15,5 +15,13 @@
         app:layout_constraintStart_toStartOf="parent"
         app:layout_constraintTop_toTopOf="parent" />
 
+    <View
+        android:id="@+id/full_screen_button"
+        android:layout_width="44dp"
+        android:layout_height="44dp"
+        android:layout_margin="8dp"
+        app:layout_constraintEnd_toEndOf="@id/yt_player"
+        app:layout_constraintBottom_toBottomOf="@id/yt_player"/>
+
 </androidx.constraintlayout.widget.ConstraintLayout>
 


### PR DESCRIPTION
* add full_screen_button view for handling fullScreen button clicks
* add full_screen_button view clicked stateFlow for saving screen rotation state if the autorotation function is enables in VideoPlayerViewModel
* add StateHoesting principles in the VideoPlayerViewModel
* move out OrientationHandler from YouTubePlayerHandler
* add screen rotation logic for both autorotation is enabled and disabled