### PR TITLE
TSK-ID-14 Fix ShortsScreen loads shorts infinitely

### DIFF
--- a/app/src/androidTest/java/com/appelier/bluetubecompose/ui/screens/shorts_screen/ShortsScreenKtTest.kt
+++ b/app/src/androidTest/java/com/appelier/bluetubecompose/ui/screens/shorts_screen/ShortsScreenKtTest.kt
@@ -4,11 +4,11 @@ import androidx.activity.compose.setContent
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.test.assertIsDisplayed
+import androidx.compose.ui.test.assertIsNotDisplayed
 import androidx.compose.ui.test.junit4.createAndroidComposeRule
 import androidx.compose.ui.test.onAllNodesWithTag
 import androidx.compose.ui.test.onFirst
 import androidx.compose.ui.test.onNodeWithTag
-import androidx.compose.ui.test.onNodeWithText
 import androidx.navigation.compose.ComposeNavigator
 import androidx.navigation.compose.NavHost
 import androidx.navigation.compose.composable
@@ -16,12 +16,11 @@ import androidx.navigation.testing.TestNavHostController
 import androidx.paging.PagingData
 import androidx.test.ext.junit.runners.AndroidJUnit4
 import com.appelier.bluetubecompose.MainActivity
-import com.appelier.bluetubecompose.R
 import com.appelier.bluetubecompose.navigation.ScreenType
 import com.appelier.bluetubecompose.screen_shorts.screen.ShortsScreen
 import com.appelier.bluetubecompose.screen_video_list.model.videos.YoutubeVideo
 import com.appelier.bluetubecompose.utils.Core
-import com.appelier.bluetubecompose.utils.VideoItemTag
+import com.appelier.bluetubecompose.utils.ShortsItemTag
 import dagger.hilt.android.testing.HiltAndroidRule
 import dagger.hilt.android.testing.HiltAndroidTest
 import kotlinx.coroutines.flow.MutableSharedFlow
@@ -86,10 +85,10 @@ class ShortsScreenKtTest {
         init_shorts_screen()
 
         with(composeAndroidTestRule) {
-            onAllNodesWithTag(VideoItemTag.SHORTS_VIDEO_PLAYER).onFirst().assertIsDisplayed()
+            onAllNodesWithTag(ShortsItemTag.SHORTS_VIDEO_PLAYER).onFirst().assertIsDisplayed()
             onAllNodesWithTag(Core.CHANNEL_PREVIEW_IMG).onFirst().assertIsDisplayed()
-            onAllNodesWithTag(VideoItemTag.SHORTS_CHANNEL_TITLE).onFirst().assertIsDisplayed()
-            onAllNodesWithTag(VideoItemTag.SHORTS_VIDEO_TITLE).onFirst().assertIsDisplayed()
+            onAllNodesWithTag(ShortsItemTag.SHORTS_CHANNEL_TITLE).onFirst().assertIsDisplayed()
+            onAllNodesWithTag(ShortsItemTag.SHORTS_VIDEO_TITLE).onFirst().assertIsDisplayed()
         }
     }
 
@@ -99,9 +98,7 @@ class ShortsScreenKtTest {
 
         with(composeAndroidTestRule) {
             onNodeWithTag(Core.PAGING_ERROR_MSG).assertIsDisplayed()
-
-            val btnText = activity.getString(R.string.paging_error_retry_btn)
-            onNodeWithText(btnText).assertIsDisplayed()
+            onNodeWithTag(Core.CIRCULAR_PROGRESS_INDICATOR).assertIsNotDisplayed()
         }
     }
 }

--- a/app/src/androidTest/java/com/appelier/bluetubecompose/ui/screens/video_list/VideoListScreenKtTest.kt
+++ b/app/src/androidTest/java/com/appelier/bluetubecompose/ui/screens/video_list/VideoListScreenKtTest.kt
@@ -23,7 +23,7 @@ import androidx.paging.PagingData
 import androidx.test.ext.junit.runners.AndroidJUnit4
 import com.appelier.bluetubecompose.MainActivity
 import com.appelier.bluetubecompose.R
-import com.appelier.bluetubecompose.core.core_database.CustomNavTypeSerializer
+import com.appelier.bluetubecompose.navigation.CustomNavTypeSerializer
 import com.appelier.bluetubecompose.navigation.ScreenType
 import com.appelier.bluetubecompose.screen_player.OrientationState
 import com.appelier.bluetubecompose.screen_player.PlayerScreen

--- a/app/src/androidTest/java/com/appelier/bluetubecompose/ui/screens/video_player/PlayerScreenKtTest.kt
+++ b/app/src/androidTest/java/com/appelier/bluetubecompose/ui/screens/video_player/PlayerScreenKtTest.kt
@@ -27,7 +27,7 @@ import androidx.test.espresso.matcher.ViewMatchers.withId
 import androidx.test.ext.junit.runners.AndroidJUnit4
 import com.appelier.bluetubecompose.MainActivity
 import com.appelier.bluetubecompose.R
-import com.appelier.bluetubecompose.core.core_database.CustomNavTypeSerializer
+import com.appelier.bluetubecompose.navigation.CustomNavTypeSerializer
 import com.appelier.bluetubecompose.navigation.ScreenType
 import com.appelier.bluetubecompose.screen_player.PlayerScreen
 import com.appelier.bluetubecompose.screen_player.VideoPlayerViewModel

--- a/app/src/main/java/com/appelier/bluetubecompose/core/core_ui/views/PagerContentManager.kt
+++ b/app/src/main/java/com/appelier/bluetubecompose/core/core_ui/views/PagerContentManager.kt
@@ -7,6 +7,7 @@ import androidx.compose.material3.CircularProgressIndicator
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.platform.testTag
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.unit.dp
 import androidx.paging.LoadState
@@ -14,6 +15,7 @@ import androidx.paging.compose.LazyPagingItems
 import com.appelier.bluetubecompose.R
 import com.appelier.bluetubecompose.core.core_ui.views.video_list_screen.PaginationErrorItem
 import com.appelier.bluetubecompose.screen_video_list.model.videos.YoutubeVideo
+import com.appelier.bluetubecompose.utils.Core
 
 @Composable
 fun PagerContentManager(
@@ -23,20 +25,27 @@ fun PagerContentManager(
 ) {
     Box(modifier = modifier, contentAlignment = Alignment.Center) {
         val refreshLoadState = videoState.loadState.refresh
-        Log.d("recomposition", "PagerContentManager() called")
 
-        when {
-            refreshLoadState is LoadState.NotLoading && videoState.itemCount > 0 -> contentList.invoke(videoState)
-            refreshLoadState is LoadState.Loading && videoState.itemCount > 0 ->
-                contentList.invoke(videoState)
-            refreshLoadState is LoadState.Loading -> CircularProgressIndicator(
+        Log.d("Empty", "videoState.itemCount = ${videoState.itemCount}")
+        when (refreshLoadState) {
+            is LoadState.NotLoading -> {
+                if (videoState.itemCount == 0) {
+                    PaginationErrorItem(
+                        errorText = castLoadState(refreshLoadState, stringResource(id = R.string.error_msg_empty_list) ),
+                        onRetryClick = { videoState.refresh() }
+                    )
+                } else contentList.invoke(videoState)
+            }
+
+            is LoadState.Loading -> CircularProgressIndicator(
                 Modifier
                     .align(Alignment.Center)
                     .height(48.dp)
+                    .testTag(Core.CIRCULAR_PROGRESS_INDICATOR)
             )
-            refreshLoadState is LoadState.Error || videoState.itemCount == 0 ->
-                PaginationErrorItem(
-                errorText = castLoadState(refreshLoadState, stringResource(id = R.string.error_msg_empty_list) ),
+
+            is LoadState.Error -> PaginationErrorItem(
+                errorText = castLoadState(refreshLoadState, stringResource(id = R.string.error_msg_empty_list)),
                 onRetryClick = { videoState.refresh() }
             )
         }

--- a/app/src/main/java/com/appelier/bluetubecompose/core/core_ui/views/shorts_screen/ShortsItem.kt
+++ b/app/src/main/java/com/appelier/bluetubecompose/core/core_ui/views/shorts_screen/ShortsItem.kt
@@ -21,9 +21,9 @@ import com.appelier.bluetubecompose.R
 import com.appelier.bluetubecompose.screen_shorts.screen.ShortsPlayerHandler
 import com.appelier.bluetubecompose.screen_video_list.model.videos.YoutubeVideo
 import com.appelier.bluetubecompose.utils.Core.CHANNEL_PREVIEW_IMG
-import com.appelier.bluetubecompose.utils.VideoItemTag.SHORTS_CHANNEL_TITLE
-import com.appelier.bluetubecompose.utils.VideoItemTag.SHORTS_VIDEO_PLAYER
-import com.appelier.bluetubecompose.utils.VideoItemTag.SHORTS_VIDEO_TITLE
+import com.appelier.bluetubecompose.utils.ShortsItemTag.SHORTS_CHANNEL_TITLE
+import com.appelier.bluetubecompose.utils.ShortsItemTag.SHORTS_VIDEO_PLAYER
+import com.appelier.bluetubecompose.utils.ShortsItemTag.SHORTS_VIDEO_TITLE
 import com.bumptech.glide.integration.compose.ExperimentalGlideComposeApi
 import com.bumptech.glide.integration.compose.GlideImage
 import com.bumptech.glide.integration.compose.placeholder

--- a/app/src/main/java/com/appelier/bluetubecompose/core/core_ui/views/shorts_screen/ShortsList.kt
+++ b/app/src/main/java/com/appelier/bluetubecompose/core/core_ui/views/shorts_screen/ShortsList.kt
@@ -39,10 +39,10 @@ fun ShortsList(
 
     VerticalPager(
         state = pagerState,
-        key = videos.itemKey(),
+        key = videos.itemKey { it },
         pageSize = PageSize.Fill,
-    ) { index: Int ->
-        videos[index]?.let {
+    ) { pageIndex: Int ->
+        videos[pageIndex]?.let {
                 ShortsItem(
                     youTubeVideo = it,
                     videoQueue

--- a/app/src/main/java/com/appelier/bluetubecompose/core/core_ui/views/video_list_screen/PaginationErrorItem.kt
+++ b/app/src/main/java/com/appelier/bluetubecompose/core/core_ui/views/video_list_screen/PaginationErrorItem.kt
@@ -26,7 +26,7 @@ fun PaginationErrorItem(
     modifier: Modifier = Modifier,
     onRetryClick: () -> Unit
 ) {
-    LaunchedEffect(Unit) { delay(500) }
+    LaunchedEffect(Unit) { delay(1000) }
     Column(horizontalAlignment = Alignment.CenterHorizontally, modifier = modifier.testTag(VIDEO_LIST_ERROR)) {
         Text(
             text = errorText ?: stringResource(id = R.string.paging_error_msg_txt),

--- a/app/src/main/java/com/appelier/bluetubecompose/utils/TestTags.kt
+++ b/app/src/main/java/com/appelier/bluetubecompose/utils/TestTags.kt
@@ -3,6 +3,7 @@ package com.appelier.bluetubecompose.utils
 object Core {
     const val CHANNEL_PREVIEW_IMG = "channel preview img"
     const val PAGING_ERROR_MSG = "paging_error_message"
+    const val CIRCULAR_PROGRESS_INDICATOR = "circular progress indicator"
 }
 
 object NavigationTags {
@@ -28,7 +29,7 @@ object VideoPlayerScreenTags {
     const val VIDEO_DESCRIPTION = "video description"
 }
 
-object VideoItemTag {
+object ShortsItemTag {
     const val SHORTS_VIDEO_PLAYER = "shorts_video_player"
     const val SHORTS_CHANNEL_TITLE = "shorts_channel_title"
     const val SHORTS_VIDEO_TITLE = "shorts_video_title"


### PR DESCRIPTION
* fix PageContentManager -> fix showing PaginationErrorItem while loading the content
* fix PaginationErrorItem -> increase delay before showing the composable
* fix ShortList -> VerticalPager used wrong item key parameter and caused to load shorts infinitely
* fix ShortsScreenKtTest to fit the changes